### PR TITLE
convert swagger 2.0 to OpenAPI 3.0.0

### DIFF
--- a/carmin.yaml
+++ b/carmin.yaml
@@ -1,6 +1,6 @@
-swagger: '2.0'
+openapi: '3.0.0'
 info:
-  version: '0.2.1'
+  version: '0.2.2'
   title: CARMIN a Common web API for Remote pipeline INvocation
   description: FLI/IAM REST API for exchanging data and remote calling pipelines.
   license:
@@ -10,514 +10,516 @@ info:
     name: CARMIN mailing list
     url: https://groups.google.com/d/forum/carmin
     email: carmin@googlegroups.com
-schemes:
-  - https 
-consumes:
-  - application/json
-produces:
-  - application/json
-
-securityDefinitions:
-  apiKey:
-      type: apiKey
-      name: apikey
-      in: header
-      description: An API key that must be provided by the platform.
 security: 
-  - apiKey: []
-
+- ApiKey: []
 paths:
   /platform:
     get:
+      summary: Returns information about the platform
       description: 
-        Returns information about the platform.
         https must be supported in the list of the supported protocols.
       operationId: getPlatformProperties
       security: []
       responses:
         '200':
           description: successful response
-          schema:
-            $ref: '#/definitions/PlatformProperties'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlatformProperties'
         default:
-          $ref: '#/responses/GenericError'
+          $ref: '#/components/responses/Error'
   /authenticate:
     post:
+      summary: Returns the api key necessary to use the API.
       description:
-        Returns the api key necessary to use the API. The key can be dynamic (a new one for each request) or static (always the same one until the user change it in a back-end)
+         The key can be dynamic (a new one for each request) or static (always the same one until the user change it in a back-end)
       operationId: authenticate
       security: []
-      parameters: 
-        - name: body
-          in: body
-          required: true
-          schema:
-            $ref: '#/definitions/AuthenticationCredentials'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AuthenticationCredentials'
       responses:
         '200':
           description: successful response
-          schema:
-            $ref: '#/definitions/Authentication'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Authentication'
         default:
-            $ref: '#/responses/GenericError'
+            $ref: '#/components/responses/Error'
   /executions:
     get:
+      summary: Lists some executions.
       description:
         list all execution Ids in the platform which are ordered in decreasing submission time.
         All the executions that were launched by the user must be returned. It is up to the platform to return executions that the user did not launch.
         When studyIdentifier is present, all the executions that the user launched in the study must be returned.
       operationId: listExecutions
       parameters:
-        - name: studyIdentifier
-          in: query
+      - name: studyIdentifier
+        in: query
+        schema:
           type: string
-        - name: offset
-          in: query
-          type: integer
-        - name: limit
-          in: query
-          type: integer
+      - name: offset
+        in: query
+        schema:
+          type: string
+      - name: limit
+        in: query
+        schema:
+          type: string
       responses:
         '200':
           description: successful response
-          schema:
-            type: array
-            items:
-              $ref: '#/definitions/Execution'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Execution'
         default:
-          $ref: '#/responses/GenericError'
+          $ref: '#/components/responses/Error'
     post:
+      summary: Initializes an execution
       description:
-        Initializes an execution. The successful response must contain the execution identifier. If status “Initializing” is returned, playExecution must be called to start the execution.
+        The successful response must contain the execution identifier. 
+        If the status “Initializing” is returned, playExecution must be called to start the execution.
       operationId: createExecution
-      parameters:
-        - name: body
-          in: body
-          required: true
-          schema:
-            $ref: '#/definitions/Execution'
+      requestBody :
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Execution'
       responses:
         '200':
           description: successful response
-          schema:
-            $ref: '#/definitions/Execution'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Execution'
         default:
-          $ref: '#/responses/GenericError'
+          $ref: '#/components/responses/Error'
   /executions/count:
     get:
+      summary: Give the number of the user's executions
       operationId: countExecutions
       parameters:
-        - name: studyIdentifier
-          in: query
+      - name: studyIdentifier
+        in: query
+        schema:
           type: string
       responses:
         '200':
           description: successful response
-          schema:
-            type: integer
+          content:
+            text/plain:
+              schema:
+                type: integer
         default:
-          $ref: '#/responses/GenericError'
+          $ref: '#/components/responses/Error'
   /executions/{executionIdentifier}:
     parameters:
-      - name: executionIdentifier
-        in: path
-        required: true      
-        type: string
-        format: ascii
+    - $ref: '#/components/parameters/PathExecutionIdentifier'
     get:
-      description: get information about an execution
+      summary: get information about an execution
       operationId: getExecution
       responses:
         '200':
           description: successful response
-          schema:
-            $ref: '#/definitions/Execution'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Execution'
         default:
-          $ref: '#/responses/GenericError'
+          $ref: '#/components/responses/Error'
     put:
+      summary: Modify an execution. 
       description:
-        Modify an execution. Only the name and the timeout of the execution can be modified. Changes to the identifier or the status will raise errors. Changes to the other properties will be ignored.
+        Only the name and the timeout of the execution can be modified. 
+        Changes to the identifier or the status will raise errors. 
+        Changes to the other properties will be ignored.
       operationId: updateExecution
-      parameters:
-        - name: body
-          in: body
-          required: true
-          schema:
-            $ref: '#/definitions/Execution'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Execution'
       responses:
         '204':
           description: successful response
         default:
-          $ref: '#/responses/GenericError'
+          $ref: '#/components/responses/Error'
   /executions/{executionIdentifier}/results:
     get:
-      description: get the result files of the execution
+      summary: get the result files of the execution
       operationId: getExecutionResults
-      produces:
-      - application/json
       parameters:
-      - name: executionIdentifier
-        in: path
-        required: true
-        type: string
-        format: ascii
+      - $ref: '#/components/parameters/PathExecutionIdentifier'
       - name: protocol
         in: query
-        type: string
         description: if not specified the default protocol is https
+        schema:
+          type: string
       responses:
         '200':
           description: successful response
-          schema:
-            type: array
-            items:
-              type: string
-              format: url
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+                  format: url
         default:
-          $ref: '#/responses/GenericError'
+          $ref: '#/components/responses/Error'
   /executions/{executionIdentifier}/stdout:
     get:
-      description: get stdout of an execution
+      summary: get stdout of an execution
       operationId: getStdout
-      produces:
-      - text/plain
-      - application/json
       parameters:
-      - name: executionIdentifier
-        in: path
-        required: true
-        type: string
-        format: ascii
+      - $ref: '#/components/parameters/PathExecutionIdentifier'
       responses:
         '200':
           description: successful response
-          schema:
-            type: string
+          content:
+            text/plain:
+              schema:
+                type: string
         default:
-          $ref: '#/responses/GenericError'
+          $ref: '#/components/responses/Error'
   /executions/{executionIdentifier}/stderr:
     get:
-      description: get stderr of an execution
+      summary: get stderr of an execution
       operationId: getStderr
-      produces:
-      - text/plain
-      - application/json
       parameters:
-      - name: executionIdentifier
-        in: path
-        required: true
-        type: string
-        format: ascii
+      - $ref: '#/components/parameters/PathExecutionIdentifier'
       responses:
         '200':
           description: successful response
-          schema:
-            type: string
+          content:
+            text/plain:
+              schema:
+                type: string
         default:
-          $ref: '#/responses/GenericError'
+          $ref: '#/components/responses/Error'
   /executions/{executionIdentifier}/play:
     put:
-      description: play an execution
+      summary: play an execution
       operationId: playExecution
       parameters:
-      - name: executionIdentifier
-        in: path
-        required: true      
-        type: string
-        format: ascii
+      - $ref: '#/components/parameters/PathExecutionIdentifier'
       responses:
         '204':
           description: successful response
         default:
-          $ref: '#/responses/GenericError'
+          $ref: '#/components/responses/Error'
   /executions/{executionIdentifier}/kill:
     put:
-      description: kill an execution
+      summary: kill an execution
       operationId: killExecution
       parameters:
-      - name: executionIdentifier
-        in: path
-        required: true      
-        type: string
-        format: ascii
+      - $ref: '#/components/parameters/PathExecutionIdentifier'
       responses:
         '204':
           description: successful response
         default:
-          $ref: '#/responses/GenericError'
+          $ref: '#/components/responses/Error'
   /executions/{executionIdentifier}/delete:
     put:
+      summary: Delete an execution
       description:
-        Delete an execution. This will kill the underlying processes (if possible) and free all resources associated with this execution (depending of the configuration given in as body input).
+        This will kill the underlying processes (if possible) and free all resources associated with this execution (depending of the configuration given in as body input).
       operationId: deleteExecution
       parameters:
-        - name: executionIdentifier
-          in: path
-          required: true      
-          type: string
-          format: ascii
-        - name: body
-          in: body
-          description: delete configuration
-          schema:
-            $ref: '#/definitions/DeleteExecutionConfiguration'
+      - $ref: '#/components/parameters/PathExecutionIdentifier'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeleteExecutionConfiguration'
       responses:
         '204':
           description: successful response
         default:
-          $ref: '#/responses/GenericError'
+          $ref: '#/components/responses/Error'
   /pipelines:
     get:
+      summary: List pipelines
       description:
         All the pipelines that the user can execute must be returned.
         It is up to the platform to return pipelines that the user cannot execute.
         When studyIdentifier is present, all the pipelines that the user can execute in the study must be returned. In this case, execution rights denote the rights to execute the pipeline in the study.
       operationId: listPipelines
       parameters:
-        - name: studyIdentifier
-          in: query
+      - name: studyIdentifier
+        in: query
+        schema:
           type: string
           format: ascii
       responses:
         '200':
           description: successful response
-          schema:
-            type: array
-            items:
-              $ref: '#/definitions/Pipeline'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pipeline'
         default:
-          $ref: '#/responses/GenericError'
+          $ref: '#/components/responses/Error'
   /pipelines/{pipelineIdentifier}:
     get:
-      description: Show the definition of a given pipeline
+      summary: Show the definition of a pipeline
       operationId: getPipeline
       parameters:
-        - name: pipelineIdentifier
-          in: path
-          required: true
-          description: pipeline identifier
+      - name: pipelineIdentifier
+        in: path
+        required: true
+        schema:
           type: string
           format: ascii
       responses:
         '200':
           description: successful response
-          schema:
-            $ref: '#/definitions/Pipeline'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pipeline'
         default: 
-          $ref: '#/responses/GenericError'
-responses:
-  GenericError:
-    description: An functional or internal error occured processing the request
-    schema:
-      $ref: '#/definitions/ErrorCodeAndMessage'
-definitions:
-  AuthenticationCredentials:
-    type: object
-    required:
-      - username
-      - password
-    properties:
-      username:
+          $ref: '#/components/responses/Error'      
+components:
+  securitySchemes:
+    ApiKey:
+      type: apiKey
+      name: apikey
+      in: header
+      description: An API key that must be provided by the platform.
+  parameters:
+    PathExecutionIdentifier:
+      name: executionIdentifier
+      in: path
+      required: true   
+      schema:
         type: string
-      password:
-        type: string
-  Authentication:
-    type: object
-    required:
-      - httpHeader
-      - httpHeaderValue
-    properties:
-      httpHeader:
-        type: string
-      httpHeaderValue:
-        type: string
-  PlatformProperties:
-    type: object
-    required:
-      - supportedTransferProtocols
-      - supportedModules
-      - supportedAPIVersion
-    properties:
-      platformName: # not present in 0.2 version, keep it as optional
-        type: string
-        description: Name of the platform.
-      APIErrorCodesAndMessages:
-        type: array
-        items:
-          $ref: '#/definitions/ErrorCodeAndMessage'
-      supportedTransferProtocols:
-        type: array
-        items:
+        format: ascii
+  responses:
+    Error:
+      description: An functional or internal error occured processing the request
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorCodeAndMessage'
+  schemas:
+    ErrorCodeAndMessage:
+      type: object
+      required:
+        - errorCode
+        - errorMessage
+      properties:
+        errorCode:
+          type: integer
+          format: int64
+        errorMessage:
           type: string
-          enum: ["http", "https", "ftp", "sftp", "ftps", "scp", "webdav"]
-        description:
-          Protocol names must be URL prefixes (e.g. "http", "https", "ftp", "sftp", "ftps", "scp", "webdav"). 
-      supportedModules:
-        type: array
-        items:
+    PlatformProperties:
+      type: object
+      required:
+        - supportedTransferProtocols
+        - supportedModules
+        - supportedAPIVersion
+      properties:
+        platformName: # not present in 0.2 version, keep it as optional
           type: string
-          enum: ["Processing", "Data", "AdvancedData", "Management", "Commercial", ]
-      defaultLimitListExecutions: # not present in 0.2, keep it as optional
-        type: integer
-        format: int64
-        description: The number of Executions returned by getExecutions
-      email:
-        type: string
-        format: email
-      platformDescription:
-        type: string
-      minAuthorizedExecutionTimeout:
-        type: integer
-        format: int64
-      maxAuthorizedExecutionTimeout:
-        type: integer
-        format: int64
-        description: 0 or absent means no max timeout. max has to be greater or equal to the min.
-      defaultExecutionTimeout:
-        type: integer
-        format: int64
-      unsupportedMethods: 
-      # not present in 0.2, keep it as optional
-        type: array
-        items:
-          type: string
-        description: List of optional methods that are not supported by the platform. Must be consistent with the "isKillExecutionSupported" property.
-      defaultStudy:
-        type: string
-        format: ascii
-      supportedAPIVersion:
-        type: string
-        format: ascii
-    additionalProperties: true # allow extensions
-  Pipeline:
-    type: object
-    required:
-      - identifier
-      - name
-      - version
-      # - parameters optional in 0.2
-    properties:
-      identifier:
-        type: string
-        format: ascii
-      name:
-        type: string
-      version:
-        type: string
-        format: ascii
-      description:
-        type: string
-      canExecute:
-        type: boolean
-        description: true if the user who requested the pipeline can execute it
-      parameters:
-        type: array
-        items:
-          $ref: '#/definitions/PipelineParameter'
-      errorCodesAndMessages:
-        type: array
-        items:
-          $ref: '#/definitions/ErrorCodeAndMessage'
-  PipelineParameter:
-    type: object
-    required:
-      - name
-      - type
-      - isOptional
-      - isReturnedValue
-    properties:
-      name:
-        type: string
-        format: ascii
-      type:
-        $ref: '#/definitions/ParameterType'
-      isOptional:
-        type: boolean
-      isReturnedValue:
-        type: boolean
-      defaultValue:
-        description: Default value. It must be consistent with the parameter type.
-      description:
-        type: string
-  ParameterType:
-    type: string
-    enum: [File,String,Boolean,Int64,Double,List]
-  ErrorCodeAndMessage:
-    type: object
-    required:
-      - errorCode
-      - errorMessage
-    properties:
-      errorCode:
-        type: integer
-        format: int64
-      errorMessage:
-        type: string
-  Execution:
-    type: object
-    required:
-      - name
-      - pipelineIdentifier
-      - inputValues
-    properties:
-      identifier:
-        type: string
-        format: ascii
-        readOnly: true
-        description: execution id. Must always be present in responses.
-      name:
-        type: string
-        description: execution name
-      pipelineIdentifier:
-        type: string
-        format: ascii
-        description: which pipeline that started this execution
-      timeout:
-        type: integer
-        format: int64
-        description: The timeout in seconds until which the execution is killed and deleted with all its files. 0 or absense means no timeout
-      status:
-        type: string
-        enum: [Initializing,Ready,Running,Finished,InitializationFailed,ExecutionFailed,Unknown,Killed]
-        readOnly: true
-        description: The status of the execution. Must always be present in responses.
-      inputValues:
-        type: object
-        additionalProperties: true
-        description:
-          Represents the input as a key/value object. The types should respect the parameters of the pipeline used for the execution.
-      returnedFiles:
-        type: object
-        additionalProperties:
+          description: Name of the platform.
+        APIErrorCodesAndMessages:
           type: array
-          items: 
+          items:
+            $ref: '#/components/schemas/ErrorCodeAndMessage'
+        supportedTransferProtocols:
+          type: array
+          items:
             type: string
-            format: url
-        readOnly: true
-        description: 
-          Absent when not available (e.g. execution still running). Empty if no returned file is produced.
-          Each key/value of the "returnedFiles" object corresponds to an output pipeline parameter (with "isReturnedValue" set to true) and the key must be the parameter name. The value must be an array of valid URL strings.
-          A value array can be empty if the output parameter produces no value. It can have several URLs entries when the output is a directory with several files, a big file split in several download links, several files or any other implementation specific design.
-      studyIdentifier:
-        type: string
-        format: ascii
-      errorCode:
-        type: integer
-        format: int64
-        readOnly: true
-      startDate:
-        type: integer
-        format: int64
-        description: Time in seconds since Unix epoch
-        readOnly: true
-      endDate:
-        type: integer
-        format: int64
-        description: Time in seconds since Unix epoch
-        readOnly: true
-  DeleteExecutionConfiguration:
-    type: object
-    required: [deleteFiles]
-    properties:
-      deleteFiles:
-        type: boolean
+            enum: ["http", "https", "ftp", "sftp", "ftps", "scp", "webdav"]
+          description:
+            Protocol names must be URL prefixes (e.g. "http", "https", "ftp", "sftp", "ftps", "scp", "webdav"). 
+        supportedModules:
+          type: array
+          items:
+            type: string
+            enum: ["Processing", "Data", "AdvancedData", "Management", "Commercial", ]
+        defaultLimitListExecutions: # not present in 0.2, keep it as optional
+          type: integer
+          format: int64
+          description: The number of Executions returned by getExecutions
+        email:
+          type: string
+          format: email
+        platformDescription:
+          type: string
+        minAuthorizedExecutionTimeout:
+          type: integer
+          format: int64
+        maxAuthorizedExecutionTimeout:
+          type: integer
+          format: int64
+          description: 0 or absent means no max timeout. max has to be greater or equal to the min.
+        defaultExecutionTimeout:
+          type: integer
+          format: int64
+        unsupportedMethods: 
+        # not present in 0.2, keep it as optional
+          type: array
+          items:
+            type: string
+          description: List of optional methods that are not supported by the platform. Must be consistent with the "isKillExecutionSupported" property.
+        defaultStudy:
+          type: string
+          format: ascii
+        supportedAPIVersion:
+          type: string
+          format: ascii
+      additionalProperties: true # allow extensions   
+    AuthenticationCredentials:
+      type: object
+      required:
+        - username
+        - password
+      properties:
+        username:
+          type: string
+        password:
+          type: string
+    Authentication:
+      type: object
+      required:
+        - httpHeader
+        - httpHeaderValue
+      properties:
+        httpHeader:
+          type: string
+        httpHeaderValue:
+          type: string
+    Pipeline:
+      type: object
+      required:
+        - identifier
+        - name
+        - version
+        # - parameters optional in 0.2
+      properties:
+        identifier:
+          type: string
+          format: ascii
+        name:
+          type: string
+        version:
+          type: string
+          format: ascii
+        description:
+          type: string
+        canExecute:
+          type: boolean
+          description: true if the user who requested the pipeline can execute it
+        parameters:
+          type: array
+          items:
+            $ref: '#/components/schemas/PipelineParameter'
+        errorCodesAndMessages:
+          type: array
+          items:
+            $ref: '#/components/schemas/ErrorCodeAndMessage'
+    PipelineParameter:
+      type: object
+      required:
+        - name
+        - type
+        - isOptional
+        - isReturnedValue
+      properties:
+        name:
+          type: string
+          format: ascii
+        type:
+          $ref: '#/components/schemas/ParameterType'
+        isOptional:
+          type: boolean
+        isReturnedValue:
+          type: boolean
+        defaultValue:
+          description: Default value. It must be consistent with the parameter type.
+        description:
+          type: string
+    ParameterType:
+      type: string
+      enum: [File,String,Boolean,Int64,Double,List]
+    Execution:
+      type: object
+      required:
+        - name
+        - pipelineIdentifier
+        - inputValues
+      properties:
+        identifier:
+          type: string
+          format: ascii
+          readOnly: true
+          description: execution id. Must always be present in responses.
+        name:
+          type: string
+          description: execution name
+        pipelineIdentifier:
+          type: string
+          format: ascii
+          description: which pipeline that started this execution
+        timeout:
+          type: integer
+          format: int64
+          description: The timeout in seconds until which the execution is killed and deleted with all its files. 0 or absense means no timeout
+        status:
+          type: string
+          enum: [Initializing,Ready,Running,Finished,InitializationFailed,ExecutionFailed,Unknown,Killed]
+          readOnly: true
+          description: The status of the execution. Must always be present in responses.
+        inputValues:
+          type: object
+          additionalProperties: true
+          description:
+            Represents the input as a key/value object. The types should respect the parameters of the pipeline used for the execution.
+        returnedFiles:
+          type: object
+          additionalProperties:
+            type: array
+            items: 
+              type: string
+              format: url
+          readOnly: true
+          description: 
+            Absent when not available (e.g. execution still running). Empty if no returned file is produced.
+            Each key/value of the "returnedFiles" object corresponds to an output pipeline parameter (with "isReturnedValue" set to true) and the key must be the parameter name. The value must be an array of valid URL strings.
+            A value array can be empty if the output parameter produces no value. It can have several URLs entries when the output is a directory with several files, a big file split in several download links, several files or any other implementation specific design.
+        studyIdentifier:
+          type: string
+          format: ascii
+        errorCode:
+          type: integer
+          format: int64
+          readOnly: true
+        startDate:
+          type: integer
+          format: int64
+          description: Time in seconds since Unix epoch
+          readOnly: true
+        endDate:
+          type: integer
+          format: int64
+          description: Time in seconds since Unix epoch
+          readOnly: true
+    DeleteExecutionConfiguration:
+      type: object
+      required: [deleteFiles]
+      properties:
+        deleteFiles:
+          type: boolean


### PR DESCRIPTION
I've just upgrade the swagger yaml file to OpenAPI 3.0.0 format.
This new version allow much better content type description and better polymorphism.
This would be very useful to describe the changes we want for the data module. In this case, I would like this PR to be accepted first to allow me to uptade my other PRs.

There are a lot of PROs for the version update, the CON is that the tooling for OpenAPI may not yet ready. The tooling is done by the swagger project, and I get that :
- swagger editor is released (specification validation)
- swagger UI is released (HTML documentation site)
- swagger codegen is to be released (soon but when ?)